### PR TITLE
DLF: multi-URL input, URL normalization, and shortcut fix

### DIFF
--- a/api/check.js
+++ b/api/check.js
@@ -32,8 +32,13 @@ function isPrivateHost(hostname) {
 }
 
 function normalize(raw) {
+  let value = String(raw || '').trim();
+  if (!value) return { ok: false, note: 'invalid_url' };
+  if (value.startsWith('//')) value = 'https:' + value;
+  if (!/^[a-zA-Z][a-zA-Z0-9+\.\-]*:/.test(value)) value = 'https://' + value;
+
   try {
-    const url = new URL(raw);
+    const url = new URL(value);
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return { ok: false, note: 'unsupported_scheme' };
     if (isPrivateHost(url.hostname)) return { ok: false, note: 'private_host' };
     url.hash = '';

--- a/tools/dead-link-finder/index.html
+++ b/tools/dead-link-finder/index.html
@@ -39,7 +39,8 @@
     .export-group button { border-radius: 0.6rem; padding: 0.5rem 1rem; border: 1px solid rgba(255,255,255,0.18); background: transparent; color: inherit; cursor: pointer; }
     .export-group button:disabled { opacity: 0.4; cursor: not-allowed; }
     .toast { position: fixed; right: 16px; bottom: 16px; background: #0b1224; color: #e6edf7; border: 1px solid rgba(255,255,255,0.12); padding: 10px 14px; border-radius: 10px; z-index: 9999; box-shadow: 0 12px 30px rgba(0,0,0,0.35); }
-    .tableWrap { margin-top: 1rem; }
+    .tableWrap { margin-top: 1rem; max-height: 70vh; overflow: auto; border: 1px solid #eee; border-radius: 8px; }
+    #results thead th { position: sticky; top: 0; z-index: 2; background: #fff; box-shadow: 0 1px 0 rgba(0,0,0,0.05); }
     td .url-text { word-break: break-all; display: inline-block; max-width: 420px; }
     .cell-url { word-break: break-all; }
     .visually-hidden { position: absolute !important; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
@@ -67,22 +68,19 @@
         <h2 id="inputHeading">Input</h2>
         <fieldset class="mode-group" aria-label="Mode">
           <legend>Mode</legend>
-          <label for="modePage"><input type="radio" name="mode" id="modePage" value="crawl" checked> Page</label>
-          <label for="modeList"><input type="radio" name="mode" id="modeList" value="list"> List</label>
+          <label for="modePages"><input type="radio" name="mode" id="modePages" value="pages" checked> Pages</label>
           <label for="modeSitemap"><input type="radio" name="mode" id="modeSitemap" value="sitemap"> Sitemap</label>
         </fieldset>
 
-        <div class="mode-field" data-mode="crawl">
-          <label for="pageUrl">Page URL</label>
-          <input id="pageUrl" type="url" placeholder="https://example.com/page">
-        </div>
-        <div class="mode-field hidden" data-mode="list">
-          <label for="listInput">URLs (one per line)</label>
-          <textarea id="listInput" placeholder="https://example.com/one\nhttps://example.com/two"></textarea>
+        <div class="mode-field" data-mode="pages">
+          <label for="targetsInput">URLs of pages you want to examine
+            <span class="help">Paste one or many. Newlines, commas, or semicolons are all fine. Comments starting with # or // are ignored.</span>
+          </label>
+          <textarea id="targetsInput" rows="10" placeholder="https://example.com/page\nhttps://example.org/another"></textarea>
         </div>
         <div class="mode-field hidden" data-mode="sitemap">
           <label for="sitemapUrl">Sitemap URL</label>
-          <input id="sitemapUrl" type="url" placeholder="https://example.com/sitemap.xml">
+          <input id="sitemapUrl" placeholder="https://example.com/sitemap.xml">
         </div>
 
         <div class="options-grid" aria-label="Options">
@@ -173,10 +171,26 @@
   </footer>
 
   <script>
-    function clampInt(value, min, max, fallback) {
-      const num = Number.parseInt(value, 10);
-      if (Number.isNaN(num)) return fallback;
-      return Math.min(max, Math.max(min, num));
+    const clamp = (v, lo, hi, d) => Math.max(lo, Math.min(hi, Number(v) || d));
+
+    function stripInlineComments(line) {
+      return String(line || '').replace(/\s+#.*$/, '').replace(/\s+\/\/.*$/, '').trim();
+    }
+
+    function coerceUrl(s) {
+      s = String(s || '').trim();
+      if (!s) return '';
+      if (s.startsWith('//')) s = 'https:' + s;
+      if (!/^[a-zA-Z][a-zA-Z0-9+.\-]*:/.test(s)) s = 'https://' + s;
+      return s;
+    }
+
+    function splitMulti(val) {
+      return String(val || '')
+        .split(/[\r\n,;]+/)
+        .map(stripInlineComments)
+        .map(coerceUrl)
+        .filter(Boolean);
     }
 
     function protectCSVCell(value) {
@@ -216,8 +230,7 @@
 
     const modeRadios = document.querySelectorAll('input[name="mode"]');
     const modeFields = document.querySelectorAll('.mode-field');
-    const pageUrlEl = document.getElementById('pageUrl');
-    const listInputEl = document.getElementById('listInput');
+    const targetsInputEl = document.getElementById('targetsInput');
     const sitemapUrlEl = document.getElementById('sitemapUrl');
     const scopeEl = document.getElementById('scope');
     const includeAssetsEl = document.getElementById('includeAssets');
@@ -245,7 +258,7 @@
 
     function getSelectedMode() {
       const checked = document.querySelector('input[name="mode"]:checked');
-      return checked ? checked.value : 'crawl';
+      return checked ? checked.value : 'pages';
     }
 
     function updateModeVisibility() {
@@ -262,7 +275,7 @@
 
     function setExportState(enabled) {
       [exportCsvBtn, copyCsvBtn, exportJsonBtn, exportXlsBtn].forEach((btn) => {
-        btn.disabled = !enabled;
+        if (btn) btn.disabled = !enabled;
       });
     }
 
@@ -381,6 +394,9 @@
       }, 0);
     }
 
+    window.exportCSV = () => { if (!exportCsvBtn?.disabled) exportCsvBtn?.click(); };
+    window.copyCSV = () => { if (!copyCsvBtn?.disabled) copyCsvBtn?.click(); };
+
     exportCsvBtn.addEventListener('click', () => {
       if (!lastResults.length) return;
       download('dead-links.csv', toCSV(lastResults, meta), 'text/csv');
@@ -410,17 +426,16 @@
     function encodeState() {
       const state = {
         mode: getSelectedMode(),
-        pageUrl: pageUrlEl.value.trim(),
-        list: listInputEl.value,
-        sitemapUrl: sitemapUrlEl.value.trim(),
-        scope: scopeEl.value,
-        includeAssets: includeAssetsEl.checked,
-        respectRobots: respectRobotsEl.checked,
-        headFirst: headFirstEl.checked,
-        retryHttp: retryHttpEl.checked,
-        includeArchive: includeArchiveEl.checked,
-        timeout: clampInt(timeoutEl.value, 1000, 30000, 10000),
-        concurrency: clampInt(concurrencyEl.value, 1, 10, 10)
+        targets: targetsInputEl ? targetsInputEl.value : '',
+        sitemapUrl: sitemapUrlEl ? sitemapUrlEl.value.trim() : '',
+        scope: scopeEl ? scopeEl.value : 'internal',
+        includeAssets: includeAssetsEl ? includeAssetsEl.checked : false,
+        respectRobots: respectRobotsEl ? respectRobotsEl.checked : true,
+        headFirst: headFirstEl ? headFirstEl.checked : true,
+        retryHttp: retryHttpEl ? retryHttpEl.checked : false,
+        includeArchive: includeArchiveEl ? includeArchiveEl.checked : false,
+        timeout: clamp(timeoutEl ? timeoutEl.value : 10000, 1000, 30000, 10000),
+        concurrency: clamp(concurrencyEl ? concurrencyEl.value : 10, 1, 10, 10)
       };
       const json = JSON.stringify(state);
       const bytes = new TextEncoder().encode(json);
@@ -441,27 +456,28 @@
     }
 
     function applyState(state) {
-      const mode = state.mode || 'crawl';
+      const mode = state.mode === 'sitemap' ? 'sitemap' : 'pages';
       const radio = document.querySelector(`input[name="mode"][value="${mode}"]`);
       if (radio) radio.checked = true;
-      pageUrlEl.value = state.pageUrl || '';
-      listInputEl.value = state.list || '';
-      sitemapUrlEl.value = state.sitemapUrl || '';
-      scopeEl.value = state.scope === 'all' ? 'all' : 'internal';
-      includeAssetsEl.checked = !!state.includeAssets;
-      respectRobotsEl.checked = state.respectRobots !== false;
-      headFirstEl.checked = state.headFirst !== false;
-      retryHttpEl.checked = !!state.retryHttp;
-      includeArchiveEl.checked = !!state.includeArchive;
-      timeoutEl.value = clampInt(state.timeout, 1000, 30000, 10000);
-      concurrencyEl.value = clampInt(state.concurrency, 1, 10, 10);
+      if (targetsInputEl) {
+        const fromState = state.targets ?? state.pageUrl ?? state.list ?? '';
+        targetsInputEl.value = fromState;
+      }
+      if (sitemapUrlEl) sitemapUrlEl.value = state.sitemapUrl || state.sitemap || '';
+      if (scopeEl) scopeEl.value = state.scope === 'all' ? 'all' : 'internal';
+      if (includeAssetsEl) includeAssetsEl.checked = !!state.includeAssets;
+      if (respectRobotsEl) respectRobotsEl.checked = state.respectRobots !== false;
+      if (headFirstEl) headFirstEl.checked = state.headFirst !== false;
+      if (retryHttpEl) retryHttpEl.checked = !!state.retryHttp;
+      if (includeArchiveEl) includeArchiveEl.checked = !!state.includeArchive;
+      if (timeoutEl) timeoutEl.value = clamp(state.timeout, 1000, 30000, 10000);
+      if (concurrencyEl) concurrencyEl.value = clamp(state.concurrency, 1, 10, 10);
       updateModeVisibility();
     }
 
     const defaultState = {
-      mode: 'crawl',
-      pageUrl: '',
-      list: '',
+      mode: 'pages',
+      targets: '',
       sitemapUrl: '',
       scope: 'internal',
       includeAssets: false,
@@ -477,9 +493,9 @@
       applyState(defaultState);
     }
 
-    shareBtn.disabled = false;
+    if (shareBtn) shareBtn.disabled = false;
 
-    shareBtn.addEventListener('click', async () => {
+    shareBtn?.addEventListener('click', async () => {
       const encoded = encodeState();
       const url = `${location.origin}${location.pathname}#${encoded}`;
       try {
@@ -490,100 +506,98 @@
       }
     });
 
-    function ensureMeta(payload, data, mode) {
+    function ensureMeta(payload, data) {
       const base = data && data.meta ? { ...data.meta } : {};
+      const mode = payload.mode || base.mode || 'list';
       base.runTimestamp = base.runTimestamp || new Date().toISOString();
       base.mode = mode;
-      base.source = payload.pageUrl || payload.sitemapUrl || 'list';
-      base.concurrency = clampInt(concurrencyEl.value, 1, 10, 10);
-      base.timeoutMs = clampInt(timeoutEl.value, 1000, 30000, 10000);
-      base.robots = payload.respectRobots;
-      base.scope = payload.scope;
-      base.assets = payload.includeAssets;
-      base.httpFallback = payload.retryHttp;
-      base.wayback = payload.includeArchive;
+      const source = payload.pageUrl || payload.sitemapUrl || (mode === 'list' ? 'list' : '');
+      base.source = source || base.source || 'list';
+      base.concurrency = clamp(concurrencyEl ? concurrencyEl.value : 10, 1, 10, 10);
+      base.timeoutMs = clamp(timeoutEl ? timeoutEl.value : 10000, 1000, 30000, 10000);
+      base.robots = payload.respectRobots !== false;
+      base.scope = payload.scope || 'internal';
+      base.assets = !!payload.includeAssets;
+      base.httpFallback = payload.retryHttp || false;
+      base.wayback = payload.includeArchive || false;
       base.totalQueued = base.totalQueued ?? data?.totalQueued ?? lastResults.length;
       base.totalChecked = base.totalChecked ?? lastResults.length;
       base.truncated = base.truncated ?? !!data?.truncated;
       return base;
     }
 
-    runBtn.addEventListener('click', async () => {
-      const mode = getSelectedMode();
-      const timeoutMs = clampInt(timeoutEl.value, 1000, 30000, 10000);
-      const concurrency = clampInt(concurrencyEl.value, 1, 10, 10);
-
-      const payload = {
-        mode,
-        scope: scopeEl.value,
-        includeAssets: includeAssetsEl.checked,
-        respectRobots: respectRobotsEl.checked,
-        headFirst: headFirstEl.checked,
-        retryHttp: retryHttpEl.checked,
-        includeArchive: includeArchiveEl.checked,
-        timeout: timeoutMs,
-        concurrency
+    async function buildPayload() {
+      const base = {
+        respectRobots: respectRobotsEl ? respectRobotsEl.checked : true,
+        scope: scopeEl ? scopeEl.value : 'internal',
+        includeAssets: includeAssetsEl ? includeAssetsEl.checked : false,
+        headFirst: headFirstEl ? headFirstEl.checked : true,
+        retryHttp: retryHttpEl ? retryHttpEl.checked : false,
+        includeArchive: includeArchiveEl ? includeArchiveEl.checked : false,
+        timeout: clamp(timeoutEl ? timeoutEl.value : 10000, 1000, 30000, 10000),
+        concurrency: clamp(concurrencyEl ? concurrencyEl.value : 10, 1, 10, 10)
       };
 
-      if (mode === 'crawl') {
-        payload.pageUrl = pageUrlEl.value.trim();
-        if (!payload.pageUrl) {
-          progressEl.textContent = 'Please enter a page URL to crawl.';
-          pageUrlEl.focus();
-          return;
+      const mode = getSelectedMode();
+      if (mode === 'sitemap') {
+        const raw = sitemapUrlEl ? sitemapUrlEl.value : '';
+        const value = coerceUrl(stripInlineComments(raw));
+        if (!value) {
+          throw new Error('Please enter a sitemap URL.');
         }
-      } else if (mode === 'list') {
-        const raw = listInputEl.value.trim();
-        if (!raw) {
-          progressEl.textContent = 'Please enter at least one URL.';
-          listInputEl.focus();
-          return;
-        }
-        const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
-        if (!lines.length) {
-          progressEl.textContent = 'Please enter at least one valid URL.';
-          listInputEl.focus();
-          return;
-        }
-        if (lines.length > 1000) {
-          showToast('Only the first 1000 URLs will be checked to stay polite.');
-        }
-        payload.list = lines.slice(0, 1000).join('\n');
-      } else if (mode === 'sitemap') {
-        payload.sitemapUrl = sitemapUrlEl.value.trim();
-        if (!payload.sitemapUrl) {
-          progressEl.textContent = 'Please enter a sitemap URL.';
-          sitemapUrlEl.focus();
-          return;
-        }
+        return { ...base, mode: 'sitemap', sitemapUrl: value };
       }
 
-      progressEl.textContent = 'Running…';
-      runBtn.disabled = true;
-      setExportState(false);
-      resultsBody.innerHTML = '';
-      summaryEl.textContent = '';
+      const rawTargets = targetsInputEl ? targetsInputEl.value : '';
+      let urls = splitMulti(rawTargets);
+      const unique = Array.from(new Set(urls));
+      if (unique.length > 200) {
+        showToast('Only the first 200 URLs will be checked to stay polite.');
+      }
+      urls = unique.slice(0, 200);
 
+      if (urls.length === 0) {
+        throw new Error('Please enter at least one URL.');
+      }
+
+      if (urls.length === 1) {
+        return { ...base, mode: 'crawl', pageUrl: urls[0] };
+      }
+
+      return { ...base, mode: 'list', list: urls.join('\n') };
+    }
+
+    runBtn?.addEventListener('click', async (event) => {
+      event.preventDefault();
+      progressEl.textContent = '';
+      runBtn.disabled = true;
       try {
-        const response = await fetch('/api/check', {
+        const payload = await buildPayload();
+        progressEl.textContent = 'Running…';
+        setExportState(false);
+        resultsBody.innerHTML = '';
+        summaryEl.textContent = '';
+
+        const res = await fetch('/api/check', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'content-type': 'application/json' },
           body: JSON.stringify(payload)
         });
-        const data = await response.json();
-        if (!response.ok) {
-          throw new Error(data && data.message ? data.message : `Request failed (${response.status})`);
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data && data.message ? data.message : `Request failed (${res.status})`);
         }
         lastResults = Array.isArray(data.results) ? data.results : [];
-        meta = ensureMeta(payload, data, mode);
+        meta = ensureMeta(payload, data);
         renderRows(lastResults);
         const broken = lastResults.filter((row) => !row.ok).length;
         const truncatedLabel = meta.truncated ? ' (soft cap reached)' : '';
         summaryEl.textContent = `${lastResults.length} checked · ${broken} broken${truncatedLabel}`;
         setExportState(lastResults.length > 0);
         progressEl.textContent = 'Done';
-      } catch (error) {
-        progressEl.textContent = 'Error: ' + error.message;
+      } catch (err) {
+        progressEl.textContent = 'Error: ' + (err?.message || 'Run failed');
+        alert(err?.message || 'Run failed');
         lastResults = [];
         meta = null;
       } finally {
@@ -591,10 +605,9 @@
       }
     });
 
-    clearBtn.addEventListener('click', () => {
-      listInputEl.value = '';
-      pageUrlEl.value = '';
-      sitemapUrlEl.value = '';
+    clearBtn?.addEventListener('click', () => {
+      if (targetsInputEl) targetsInputEl.value = '';
+      if (sitemapUrlEl) sitemapUrlEl.value = '';
       resultsBody.innerHTML = '';
       summaryEl.textContent = '';
       progressEl.textContent = '';
@@ -603,24 +616,17 @@
       setExportState(false);
     });
 
-    document.addEventListener('keydown', (event) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
-        event.preventDefault();
-        runBtn.click();
-      } else if (event.key.toLowerCase() === 'e') {
-        if (!exportCsvBtn.disabled) {
-          event.preventDefault();
-          exportCsvBtn.click();
-        }
-      } else if (event.key.toLowerCase() === 'c') {
-        if (!copyCsvBtn.disabled) {
-          event.preventDefault();
-          copyCsvBtn.click();
-        }
-      }
+    document.addEventListener('keydown', (e) => {
+      const inField = /^(INPUT|TEXTAREA)$/.test(e.target?.nodeName) || e.target?.isContentEditable;
+      if (!e.metaKey && !e.ctrlKey) return;
+      if (inField) return;
+
+      const k = e.key.toLowerCase();
+      if (k === 'enter') { e.preventDefault(); runBtn?.click(); }
+      if (k === 'e')     { e.preventDefault(); window.exportCSV?.(); }
+      if (k === 'c')     { e.preventDefault(); window.copyCSV?.(); }
     });
 
-    // Share state restoration
     if (location.hash.length > 1) {
       const parsed = decodeState(location.hash.slice(1));
       if (parsed) {
@@ -633,5 +639,6 @@
       resetState();
     }
   </script>
+
 </body>
 </html>


### PR DESCRIPTION
Preview: _pending Vercel preview URL_

## Summary
- replace the page/list inputs with a multi-URL textarea and keep the header sticky while scrolling results
- normalize and de-duplicate URLs client-side, infer crawl vs. list automatically, and guard keyboard shortcuts behind Ctrl/Cmd
- let the Edge API normalize bare or scheme-relative URLs so direct callers receive tolerant handling

## Testing
- Manual smoke test to be run in Vercel Preview

------
https://chatgpt.com/codex/tasks/task_e_68e287b581248321af92b74c35c7fa73